### PR TITLE
Fix plugin context dependency on configured order 

### DIFF
--- a/castervoice/__main__.py
+++ b/castervoice/__main__.py
@@ -102,7 +102,7 @@ def main():
     if args.verbose > 0:
         gevent.spawn(watcher.log)
 
-    monkey.patch_all()
+    monkey.patch_all(subprocess=False)
     http_server = WSGIServer(('', 23423), web_app)
     http_server.serve_forever()
 

--- a/castervoice/__main__.py
+++ b/castervoice/__main__.py
@@ -3,7 +3,14 @@ import logging
 import os
 import sys
 
+import gevent
+import gevent.queue
+from gevent.pywsgi import WSGIServer
+from gevent import monkey
+
+from castervoice import watcher
 from castervoice.core import Controller
+from castervoice.web import app as web_app
 
 
 VERBOSITY_LOG_LEVEL = {
@@ -17,20 +24,6 @@ DEFAULT_CONFIG_DIR = "config"
 
 def default_plugin_state_dir(config_dir):
     return "{}/plugins.state".format(config_dir)
-
-
-def _on_begin():
-    print("Speech start detected.")
-
-
-def _on_recognition(words, rule, node):
-    print(u"Recognized: %s" % u" ".join(words))
-    print(u"    Executing rule: %s" % (rule))
-    print(u"    Action: %s" % (node.value()))
-
-
-def _on_failure():
-    print("Sorry, what was that?")
 
 
 def get_parser():
@@ -87,6 +80,7 @@ def main():
     :returns: TODO
 
     """
+
     args = get_args()
 
     logging.basicConfig(level=VERBOSITY_LOG_LEVEL[args.verbose])
@@ -102,10 +96,15 @@ def main():
             logging.getLogger().exception(error)
         sys.exit(1)
 
+    gevent.spawn(controller.listen, watcher.on_begin,
+                 watcher.on_recognition, watcher.on_failure)
+
     if args.verbose > 0:
-        controller.listen(_on_begin, _on_recognition, _on_failure)
-    else:
-        controller.listen()
+        gevent.spawn(watcher.log)
+
+    monkey.patch_all()
+    http_server = WSGIServer(('', 23423), web_app)
+    http_server.serve_forever()
 
 
 if __name__ == "__main__":

--- a/castervoice/core/context.py
+++ b/castervoice/core/context.py
@@ -7,18 +7,32 @@ from dragonfly import (
 
 class Context(DragonflyContext):
 
-    """Docstring for myclass. """
-
-    def __init__(self, manager, config):
+    def __init__(self, name, manager):
         """TODO: to be defined. """
 
         super().__init__()
 
-        self._str = config.pop("name")
+        self._str = name
         self._name = self._str
         self._enabled = True
 
         self._contexts = []
+
+        self.manager = manager
+
+    def matches(self, executable, title, handle):
+        return self._enabled and LogicAndContext(*self._contexts) \
+            .matches(executable, title, handle)
+
+
+class ConfigContext(Context):
+
+    """Interpret context from Caster configuration"""
+
+    def __init__(self, manager, config):
+        """TODO: to be defined. """
+
+        super().__init__(config.pop("name"), manager)
 
         executable = config.pop("executable", None)
         title = config.pop("title", None)
@@ -28,18 +42,48 @@ class Context(DragonflyContext):
 
         # Apply plugin specific contexts
         for plugin_id, desired_state in config.items():
-            try:
-                plugin_context = manager.get_plugin_context(plugin_id,
-                                                            desired_state)
-                self._contexts.append(plugin_context)
 
-            except Exception as error:  # pylint: disable=W0703
-                manager.log.exception("Error while applying plugin specific"
-                                      " context in context '%s'."
-                                      " Unable to get context for plugin"
-                                      " %s: %s" % (self._name, plugin_id,
-                                                   error))
+            self._contexts.append(
+                    PluginContext(manager, plugin_id, desired_state))
+
+
+class PluginContext(Context):
+
+    """Lazily loads plugin contexts on matching
+
+    Plugin contexts may not be available at start up
+    while plugins are still loaded sequentially.
+
+    """
+
+    def __init__(self, manager, plugin_id, desired_state):
+
+        super().__init__(plugin_id, manager)
+
+        self._plugin_id = plugin_id
+        self._desired_state = desired_state
+
+        self._loaded = False
+
+    def load(self):
+        try:
+            plugin_context = self.manager \
+                .get_plugin_context(self._plugin_id,
+                                    self._desired_state)
+            self._contexts.append(plugin_context)
+
+        except Exception as error:  # pylint: disable=W0703
+            self.manager.log.exception(
+                    "Error while applying plugin specific"
+                    " context in context '%s'."
+                    " Unable to get context for plugin"
+                    " %s: %s" % (self._name,
+                                 self._plugin_id,
+                                 error))
 
     def matches(self, executable, title, handle):
-        return self._enabled and LogicAndContext(*self._contexts) \
-            .matches(executable, title, handle)
+        if not self._loaded:
+            self.load()
+            self._loaded = True
+
+        return super().matches(executable, title, handle)

--- a/castervoice/core/context_manager.py
+++ b/castervoice/core/context_manager.py
@@ -2,7 +2,7 @@ import logging
 
 from dragonfly.grammar.context import LogicOrContext, LogicAndContext
 
-from castervoice.core.context import Context
+from castervoice.core.context import ConfigContext
 
 
 class ContextManager():
@@ -45,7 +45,7 @@ class ContextManager():
             context_plugins = context_config.pop("plugins", [])
             extends = context_config.pop("extends", None)
 
-            context = Context(self, context_config)
+            context = ConfigContext(self, context_config)
 
             if isinstance(extends, str):
                 extended_context = self._contexts.get(extends)

--- a/castervoice/core/controller.py
+++ b/castervoice/core/controller.py
@@ -86,7 +86,8 @@ class Controller:
 
         if isinstance(config_dir, str):
             try:
-                with open(config_dir + "/caster.yml", "r") as ymlfile:
+                config_file = config_dir + "/caster.yml"
+                with open(config_file, "r", encoding='UTF-8') as ymlfile:
                     config_from_file = yaml.load(ymlfile, Loader=Loader)
                     if config_from_file is not None:
                         config_result.update(config_from_file)
@@ -101,7 +102,7 @@ class Controller:
                 return self.load_config(config, config_dir)
 
         if "plugins" not in config_result:
-            config_result["plugins"] = dict()
+            config_result["plugins"] = {}
         if "contexts" not in config_result:
             config_result["contexts"] = []
 
@@ -117,7 +118,8 @@ class Controller:
 
             os.mkdir(config_dir)
 
-        with open(config_dir + "/caster.yml", 'w') as config_file:
+        config_file = config_dir + "/caster.yml"
+        with open(config_file, 'w', encoding='UTF-8') as config_file:
             config_file.write(pkg_resources.read_text(casterconfig,
                                                       'caster.yml'))
 

--- a/castervoice/core/dependency_manager.py
+++ b/castervoice/core/dependency_manager.py
@@ -71,9 +71,9 @@ class ModuleReloader(importlib.abc.MetaPathFinder):
         # 'casterplugin.dictation') and value contains the entries
         # `module` (module object) and `dependencies`
         # (list of modules which the module depends on)
-        self._modules = dict()
+        self._modules = {}
 
-        self.watched_plugin_modules = dict()
+        self.watched_plugin_modules = {}
 
         get_current_engine().create_timer(self.reload, 10)
 
@@ -114,11 +114,11 @@ class ModuleReloader(importlib.abc.MetaPathFinder):
                     except AttributeError:
                         m = sys.modules[m.__name__ + '.' + component]
 
-            module = self._modules.setdefault(name, dict())
+            module = self._modules.setdefault(name, {})
             module["module"] = m
 
             if parent is not None:
-                parent_module = self._modules.setdefault(parent, dict())
+                parent_module = self._modules.setdefault(parent, {})
                 # If this is a nested import for a reloadable (source-based)
                 # module, we append ourself to our parent's dependency list.
                 if hasattr(m, '__file__'):

--- a/castervoice/core/plugin/plugin.py
+++ b/castervoice/core/plugin/plugin.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import os
 import yaml
@@ -60,6 +61,9 @@ class Plugin():
 
     config = property(lambda self: self._manager.get_config(self._id),
                       doc="Plugin config.")
+
+    grammars = property(lambda self: copy.deepcopy(self._grammars),
+                        doc="Plugin grammars.")
 
     def persist_state(self):
         self._state.persist()

--- a/castervoice/core/plugin/plugin.py
+++ b/castervoice/core/plugin/plugin.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import os
 import yaml
@@ -62,7 +61,7 @@ class Plugin():
     config = property(lambda self: self._manager.get_config(self._id),
                       doc="Plugin config.")
 
-    grammars = property(lambda self: copy.deepcopy(self._grammars),
+    grammars = property(lambda self: self._grammars,
                         doc="Plugin grammars.")
 
     def persist_state(self):
@@ -186,7 +185,7 @@ class PluginFile:
         self._type = self.__class__.__name__
 
         try:
-            with open(file_path, "r") as ymlfile:
+            with open(file_path, "r", encoding='UTF-8') as ymlfile:
                 self._data = yaml.load(ymlfile, Loader=Loader)
         except yaml.YAMLError as error:
             print("Error in {} file: {}".format(self._type, error))
@@ -209,5 +208,5 @@ class PluginState(PluginFile):
         super().__init__(file_path)
 
     def persist(self):
-        with open(self._file_path, 'w') as ymlfile:
+        with open(self._file_path, 'w', encoding='UTF-8') as ymlfile:
             ymlfile.write(yaml.dump(self._data, Dumper=Dumper))

--- a/castervoice/watcher.py
+++ b/castervoice/watcher.py
@@ -21,9 +21,14 @@ def new_queue():
 
 
 def on_recognition(words, rule, node):
+    plugin_name = None
     for plugin_name, plugin in Controller.get().plugin_manager.plugins.items():
         if rule.grammar in plugin.grammars:
             break
+
+    # It would be odd recognizing a rule which is not present in
+    # any plugin's grammar
+    assert plugin_name
 
     recognition_event = RecognitionEvent(plugin_name, words, rule, node)
     for queue in consumer_queues:

--- a/castervoice/watcher.py
+++ b/castervoice/watcher.py
@@ -1,0 +1,56 @@
+import gevent.queue
+
+from castervoice.core.controller import Controller
+
+consumer_queues = []
+
+
+class RecognitionEvent:
+
+    def __init__(self, plugin_name, words, rule, node):
+        self.plugin_name = plugin_name
+        self.words = words
+        self.rule = rule
+        self.node = node
+
+
+def new_queue():
+    queue = gevent.queue.Queue()
+    consumer_queues.append(queue)
+    return queue
+
+
+def on_recognition(words, rule, node):
+    for plugin_name, plugin in Controller.get().plugin_manager.plugins.items():
+        if rule.grammar in plugin.grammars:
+            break
+
+    recognition_event = RecognitionEvent(plugin_name, words, rule, node)
+    for queue in consumer_queues:
+        queue.put_nowait(recognition_event)
+
+
+def on_begin():
+    print("Speech start detected.")
+
+
+def on_failure():
+    print("Sorry, what was that?")
+
+
+def log():
+    queue = new_queue()
+    while True:
+        reco = queue.get()
+        print("Recognized: %s" % " ".join(reco.words))
+        print("    Executing rule: %s" % (reco.rule))
+        print("    Action: %s" % (reco.node.value()))
+
+
+def stream_recognitions():
+    queue = new_queue()
+
+    while True:
+        reco = queue.get()
+        s = "%s: %s" % (reco.plugin_name, " ".join(reco.words))
+        yield "data: %s\n\n" % s

--- a/castervoice/web/__init__.py
+++ b/castervoice/web/__init__.py
@@ -1,0 +1,69 @@
+from flask import Flask, Response, request
+
+from castervoice.watcher import stream_recognitions
+
+app = Flask(__package__)
+
+
+@app.route('/events')
+def index():
+    if request.headers.get('accept') == 'text/event-stream':
+        return Response(stream_recognitions(),
+                        content_type='text/event-stream')
+    return """
+<!doctype html>
+<title>Caster-Core Events</title>
+<style>
+  html {
+    height: 10%
+  }
+  body,p {
+    white-space: nowrap;
+    margin: 0;
+    padding: 0;
+    text-align: left;
+  }
+  #data {
+    text-align: center;
+    #background-color: yellow;
+    display: inline-block;
+  }
+  .hidden {
+    display: none;
+  }
+  .entry {
+    background: rgba(255,255,255,0.8);
+    display: block;
+    margin: 0px 6px;
+
+    animation: signup-response 1s;
+    animation-delay: 10.0s;
+    -webkit-animation: signup-response 1s;
+    -webkit-animation-delay: 10.0s;
+  }
+
+  @keyframes signup-response{
+      from {opacity :1;}
+      to {opacity :0;}
+  }
+
+  @-webkit-keyframes signup-response{
+      from {opacity :1;}
+      to {opacity :0;}
+  }
+</style>
+<script src="http://code.jquery.com/jquery-latest.js"></script>
+<script>
+if (!!window.EventSource) {
+  var source = new EventSource('/events');
+  var logs = []
+  var max_entries = 10
+  source.onmessage = function(e) {
+    $("#data").append('<p class="entry">' + e.data + '</p>');
+
+    setTimeout(function(){$("#data").find(':first-child').remove()}, 11000);
+  }
+}
+</script>
+<div id="data"></div>
+"""

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,7 @@ setuptools.setup(
     install_requires=[
         "PyYAML",
         "dragonfly2[kaldi]>=0.28.0",
+        "gevent",
+        "flask"
     ],
 )


### PR DESCRIPTION


Previously plugins were loaded in the order
they appeared in the configuration file and at
the same time plug in context references were
resolved and loaded.

This led to the error that when a plug in required
a context from a not yet loaded plugin the loading
sequence failed.

Now plug in contexts are loaded lazily.
